### PR TITLE
Healthcheck

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()

--- a/zorak_bot/api/__init__.py
+++ b/zorak_bot/api/__init__.py
@@ -1,0 +1,3 @@
+from .api import create_app
+
+__all__ = ["create_app"]

--- a/zorak_bot/api/api.py
+++ b/zorak_bot/api/api.py
@@ -1,0 +1,33 @@
+import logging
+from posixpath import sep
+import threading
+
+from flask import Flask
+
+from .blueprints import api_routes
+
+logger = logging.getLogger(__name__)
+
+class ThreadedFlaskApp:
+    """Wrapper for a Flask object that simply allows abstraction of the run process such that it is run on a reperate thread"""
+    def __init__(self, app):
+        self.app = app
+    
+    def _start(self, host, port):
+        """Abstraction of the .run() function, technically not needed, as you could just point target to self.app.run, but it's good to visualise what's going on."""
+        self.app.run(host=host, port=port)
+
+    def run(self, host, port) -> None:
+        """Function to start the Flask App on a thread, just an abstraction of the .run() function"""
+        logging.info("Starting Kafka Consumer thread")
+        t = threading.Thread(target=self._start,kwargs={'host': host, 'port': port})
+        t.start()
+
+def create_app(seperate_thread=False):
+    app = Flask(__name__)
+    app.register_blueprint(api_routes)
+    if seperate_thread:
+        app.use_reloader=False
+        app = ThreadedFlaskApp(app)
+    return app
+

--- a/zorak_bot/api/blueprints.py
+++ b/zorak_bot/api/blueprints.py
@@ -1,0 +1,11 @@
+import logging
+
+from flask import Blueprint
+
+logger = logging.getLogger(__name__)
+api_routes = Blueprint("api_routes", __name__)
+
+
+@api_routes.route("/healthcheck")
+def health() -> dict[str, str]:
+    return {"healthcheck": "Zorak, Ready to conquer the world."}

--- a/zorak_bot/util/args_util.py
+++ b/zorak_bot/util/args_util.py
@@ -41,6 +41,8 @@ class Args:
     log_file: Path | None
     err_file: Path | None
     discord_token: str | None
+    flask_host: str | None
+    flask_port: int | None
     log_level: int = logging.INFO
     console_log: bool = True
 
@@ -69,6 +71,20 @@ def parse_args() -> Args:
         type=str,
         dest="discord_token",
         help="Token for the discord bot connection. If not included the TOKEN env variable is used.",
+    )
+    arg_parser.add_argument(
+        "-fh",
+        "--flask-host",
+        type=str,
+        dest="flask_host",
+        help="Host for the background API used for the healthcheck. Both host and port need to be included to launch a background API.",
+    )
+    arg_parser.add_argument(
+        "-fp",
+        "--flask-port",
+        type=int,
+        dest="flask_port",
+        help="Port for the background API used for the healthcheck. Both host and port need to be included to launch a background API.",
     )
     arg_parser.add_argument(
         "-lf",


### PR DESCRIPTION
added a background api with a /healthcheck route, added two new command line args that you can add when deploying that'll let you launch and configure the background API, these are _flask_host_ (string) and _flask_port_ (int). If these args are not added the API should just not launch, and if the API doesn't launch or errors out, you should get a logger message and everything will continue as normal. as always, let me know if there are any issues.