### PR TITLE
Added a service user that is common between the containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./src /src
 
-RUN set -ex \
-    # Create a user that will be a shared user between containers
-    && addgroup --system --gid 1001 service-user \
-    && adduser --system --uid 1001 --gid 1001 --no-create-home zorak-user \
-
-    # Assign ownership of the directory to this user
-    && chown -R zorak-user:service-user /src/
-
-
 WORKDIR /src
 
 # make sure all messages always reach console
 ENV PYTHONUNBUFFERED=1
 
 ENTRYPOINT ["python3", "__main__.py"]
-USER zorak-user

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,20 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./src /src
+
+RUN set -ex \
+    # Create a user that will be a shared user between containers
+    && addgroup --system --gid 1001 service-user \
+    && adduser --system --uid 1001 --gid 1001 --no-create-home zorak-user \
+
+    # Assign ownership of the directory to this user
+    && chown -R zorak-user:service-user /src/
+
+
 WORKDIR /src
 
 # make sure all messages always reach console
 ENV PYTHONUNBUFFERED=1
 
 ENTRYPOINT ["python3", "__main__.py"]
+USER zorak-user

--- a/dc-dev.yaml
+++ b/dc-dev.yaml
@@ -5,6 +5,7 @@ services:
     container_name: zorak_mongo
     volumes:
       - ./db:/data/db
+    user: "1001"
     restart: always
 
   zorak:
@@ -19,5 +20,6 @@ services:
       - DEV_SETTINGS=True
     links:
       - "mongo:mongo"
+    user: "1001"
     depends_on:
       - mongo

--- a/dc-dev.yaml
+++ b/dc-dev.yaml
@@ -5,7 +5,7 @@ services:
     container_name: zorak_mongo
     volumes:
       - ./db:/data/db
-    user: "1001"
+    user: "1000"
     restart: always
 
   zorak:
@@ -20,6 +20,6 @@ services:
       - DEV_SETTINGS=True
     links:
       - "mongo:mongo"
-    user: "1001"
+    user: "1000"
     depends_on:
       - mongo

--- a/dc-prod.yaml
+++ b/dc-prod.yaml
@@ -5,6 +5,7 @@ services:
     container_name: zorak_mongo
     volumes:
       - ./db:/data/db
+    user: "1001"
     restart: always
 
   zorak:
@@ -16,4 +17,5 @@ services:
       - "mongo:mongo"
     depends_on:
       - mongo
+    user: "1001"
     restart: always

--- a/dc-prod.yaml
+++ b/dc-prod.yaml
@@ -5,7 +5,7 @@ services:
     container_name: zorak_mongo
     volumes:
       - ./db:/data/db
-    user: "1001"
+    user: "1002"
     restart: always
 
   zorak:
@@ -17,5 +17,5 @@ services:
       - "mongo:mongo"
     depends_on:
       - mongo
-    user: "1001"
+    user: "1002"
     restart: always


### PR DESCRIPTION
This service user will be used as a base permissions user between the DB and any containers that get built, allowing us to persist the DB without permissions problems.