### PR TITLE
Update utility_run_code.py

### DIFF
--- a/src/cogs/utility/utility_run_code.py
+++ b/src/cogs/utility/utility_run_code.py
@@ -25,10 +25,14 @@ class UtilityRunCode(commands.Cog):
                     , ctx.author.name
                     , ctx.command)
 
+        # Adjust iOS quotation marks “”‘’ to avoid SyntaxError: invalid character 
+        codeblock.translate(codeblock.maketrans("“”‘’", """""''"""))
+
         piston = PistonAPI()
         if codeblock.startswith("```py") is True:
             if codeblock.endswith("```") is True:
-                codeblock = codeblock.replace("```py", "").replace("```", "").strip()
+                # Remove backticks and py/python language indicator from codeblock
+                codeblock = codeblock.replace("```python", "").replace("```py", "").replace("```", "").strip()
             runcode = piston.execute(language="py", version="3.10.0", code=codeblock)
             embed = discord.Embed(colour=discord.Colour.green(), title="Python 3.10")
             embed.add_field(name="Output:", value=runcode)


### PR DESCRIPTION
Added a quick translate() method to the codeblock text so Zorak will no longer throw an error when iOS users use incorrect single or double quotation marks.

Added a replace() method to the codeblock to account for users who begin their codeblock with \`\`\`python instead of \`\`\`py to avoid `NameError: name 'thon' is not defined`.