### PR TITLE
fix: Update logging_member_roles.py

### DIFF
--- a/src/zorak/cogs/logging/logging_member_roles.py
+++ b/src/zorak/cogs/logging/logging_member_roles.py
@@ -31,12 +31,14 @@ class LoggingRoles(commands.Cog):
             responsible_member = audit_log.user
 
             changed_roles = []
+            logs_channel = await self.bot.fetch_channel(self.bot.server_settings.log_channel["mod_log"])
             if len(before.roles) > len(after.roles):
                 for role in before.roles:
                     if role not in after.roles:
                         changed_roles.append(role)
                 for item in changed_roles:
                     embed = embed_role_remove(target_member, responsible_member, item)
+                    await logs_channel.send(embed=embed)
 
             elif len(before.roles) < len(after.roles):
                 for role in after.roles:
@@ -44,9 +46,8 @@ class LoggingRoles(commands.Cog):
                         changed_roles.append(role)
                 for item in changed_roles:
                     embed = embed_role_add(target_member, responsible_member, item)
+                    await logs_channel.send(embed=embed)
 
-            logs_channel = await self.bot.fetch_channel(self.bot.server_settings.log_channel["mod_log"])
-            await logs_channel.send(embed=embed)  # Fix - possibly unbound local variable 'embed'
 
 
 def setup(bot):


### PR DESCRIPTION
Should fix the recurring errors in the logs

`Ignoring exception in on_member_update
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/discord/client.py", line 378, in _run_event
    await coro(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/zorak/cogs/logging/logging_member_roles.py", line 49, in on_member_update
    await logs_channel.send(embed=embed)  # Fix - possibly unbound local variable 'embed'
UnboundLocalError: local variable 'embed' referenced before assignment`

fixes #161 