### PR TITLE
Color roles

### DIFF
--- a/Resources/ServerConfig/PracticalPython/reaction_roles.toml
+++ b/Resources/ServerConfig/PracticalPython/reaction_roles.toml
@@ -17,6 +17,17 @@ oceana = 974951025050025984
 open_to_work = 1113020825596067850
 employer = 1113020504148815944
 
+[reaction_roles.color]
+red = 1148145845770915870
+orange = 1148145321302560769
+yellow = 1148145167736520764
+light_green = 1148144840735981569
+dark_green = 1148147946068643900
+light_blue = 1148144625836625961
+blue = 1148144828631224391
+pink = 1143109787316396082
+purple = 1148146380880216065
+
 [selectors.experience]
 name = "experience"
 single_choice = true
@@ -50,6 +61,22 @@ options = [
 
 ]
 
+[selectors.color]
+name = "color"
+single_choice = true
+description = "Select your color!"
+options = [
+    { label = "Red", emoji = "🔴", description = "", id = 1148145845770915870 },
+    { label = "Orange", emoji = "🟠", description = "", id = 1148145321302560769 },
+    { label = "Yellow", emoji = "🟡", description = "", id = 1148145167736520764 },
+    { label = "Light Green", emoji = "🍐", description = "", id = 1148144840735981569 },
+    { label = "Dark Green", emoji = "🟢", description = "", id = 1148147946068643900 },
+    { label = "Light Blue", emoji = "🧊", description = "", id = 1148144625836625961 },
+    { label = "Blue", emoji = "🔵", description = "", id = 1148144828631224391 },
+    { label = "Pink", emoji = "💓", description = "", id = 1143109787316396082 },
+    { label = "Purple", emoji = "🟣", description = "", id = 1148146380880216065 },
+]
+
 
 #####  DEVELOPMENT
 
@@ -69,6 +96,17 @@ options = [
 #[reaction_roles.employment]
 #open_to_work = 1113020825596067850
 #employer = 1113020504148815944
+#
+#[reaction_roles.color]
+#red = 1148145845770915870
+#orange = 1148145321302560769
+#yellow = 1148145167736520764
+#light_green = 1148144840735981569
+#dark_green = 1148147946068643900
+#light_blue = 1148144625836625961
+#blue = 1148144828631224391
+#pink = 1143109787316396082
+#purple = 1148146380880216065
 #
 #[selectors.experience]
 #name = "experience"
@@ -101,4 +139,20 @@ options = [
 #    { label = "Open to Work", emoji = "🛠️", description = "You are open to taking Python related jobs.", id = 1114611004182102218 },
 #    { label = "Employer", emoji = "💼", description = "You are looking to hiring a Python developer.", id = 1114611092677722113 }
 #
+#]
+#
+#[selectors.color]
+#name = "color"
+#single_choice = true
+#description = "Select your color!"
+#options = [
+#    { label = "Red", emoji = "🔴", description = "", id = 1148145845770915870 },
+#    { label = "Orange", emoji = "🟠", description = "", id = 1148145321302560769 },
+#    { label = "Yellow", emoji = "🟡", description = "", id = 1148145167736520764 },
+#    { label = "Light Green", emoji = "🍐", description = "", id = 1148144840735981569 },
+#    { label = "Dark Green", emoji = "🟢", description = "", id = 1148147946068643900 },
+#    { label = "Light Blue", emoji = "🧊", description = "", id = 1148144625836625961 },
+#    { label = "Blue", emoji = "🔵", description = "", id = 1148144828631224391 },
+#    { label = "Pink", emoji = "💓", description = "", id = 1143109787316396082 },
+#    { label = "Purple", emoji = "🟣", description = "", id = 1148146380880216065 },
 #]


### PR DESCRIPTION
I propose adding color role selection to the /roles dropdown embed.  

This was not tested.  I read the reaction roles cog and inferred that the contents of the dropdown menu were read from the toml file so that is the only file I updated. 