### PR TITLE
Clean Up of general_trans and pronunciation feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "ffmpeg-python==0.2.0",
         "yt-dlp==2023.7.6",
         "googletrans==3.1.0a0",
-        "dnspython==2.4.2"
+        "dnspython==2.3.0"
     ],
     classifiers=[
         # see https://pypi.org/classifiers/

--- a/src/zorak/cogs/general/general_trans.py
+++ b/src/zorak/cogs/general/general_trans.py
@@ -4,94 +4,15 @@ A cog that adds translations to Zorak using the googletrans library
 
 import logging
 
-import discord.ext
-import googletrans
+import discord
 from discord.ext import commands
-from googletrans import Translator
+from googletrans import Translator, LANGUAGES
 
 
 logger = logging.getLogger(__name__)
 
-whitelist = [
-    "Python",
-    "Variable",
-    "Function",
-    "Module",
-    "List",
-    "Tuple",
-    "Dictionary",
-    "Loop",
-    "Conditional",
-    "Class",
-    "Inheritance",
-    "Polymorphism",
-    "Exception",
-    "Object",
-    "Method",
-    "Argument",
-    "Parameter",
-    "Package",
-    "Library",
-    "Syntax",
-    "Statement",
-    "Import",
-    "Return",
-    "True",
-    "False",
-    "None",
-    "Print",
-    "Input",
-    "File",
-    "Error",
-    "Debug",
-    "IDE (Integrated Development Environment)",
-    "Git",
-    "GitHub",
-    "Data",
-    "Algorithm",
-    "Algorithmic",
-    "List Comprehension",
-    "Dictionary Comprehension",
-    "Recursion",
-    "Lambda",
-    "Generator",
-    "Virtual Environment",
-    "PIP (Python Package Index)",
-    "Interpreter",
-    "Bytecode",
-    "GIL (Global Interpreter Lock)",
-    "IDE (Interactive Development Environment)",
-    "JSON (JavaScript Object Notation)",
-    "API (Application Programming Interface)",
-    "NumPy",
-    "Pandas",
-    "Matplotlib",
-    "Seaborn",
-    "Scikit-learn",
-    "TensorFlow",
-    "Keras",
-    "PyTorch",
-    "Django",
-    "Flask",
-    "Requests",
-    "Beautiful Soup",
-    "SQLAlchemy",
-    "NLTK",
-    "OpenCV",
-    "Pillow",
-    "Gensim",
-    "SciPy",
-    "SymPy",
-    "pytest",
-    "unittest",
-    "pytest-django",
-    "pytest-cov",
-    "pytest-mock",
-    "pypi",
-    "haha",
-    "pip",
-    "docker"
-]
+with open("../../utilities/cog_helpers/whitelist.txt") as f:
+    WHITE_LIST = f.read().splitlines()
 
 
 def is_multi_lang(lang):
@@ -101,15 +22,15 @@ def is_multi_lang(lang):
 
 class GoogleTranslate(commands.Cog):
     """Main class for googletrans"""
+
     def __init__(self, bot):
         """
-        Here we innit the bot, the translator object, the language list,
+        Here we innit the bot, the translator object,
         and our acceptable threshold
         """
         self.bot = bot
-        self.gl = googletrans.LANGUAGES
         self.translator = Translator()
-        self.threshold = 0.70
+        self.threshold = 0.70   #! Does this do anything?
 
     @commands.Cog.listener()
     async def on_message(self, message):
@@ -119,16 +40,26 @@ class GoogleTranslate(commands.Cog):
         if message.author.bot:
             return
 
-        if message.content.lower() in whitelist:
+        if message.content.lower() in WHITE_LIST:
             return
 
-        if len(message.content) < 7:
+        if len(message.content) < 7: #! we don't translate short words? like if someone types かわいい??
             return
 
         detected = self.translator.detect(message.content)
         multi_lang = is_multi_lang(detected.lang)
 
         if 'en' in detected.lang:
+            """
+            I worry how this works. If multiple languages are detected you would supposedly get a list
+            like ["es", "en"], correct? But if multiple languages are not detected, you would get a 
+            string like "en". Correct me if I'm wrong but it feels a bit like sloppy coding to check 
+            if x is in [either a list or a string]... because outside of this case, the condition would
+            be true if you either had a list that looked like ["ab", "cd", "en"] or if you had a 
+            string like "armenian".  I know this wont happen because you would only get languages codes
+            from detected.lang, but I would like to do things nicely. Perhaps move this condition to the
+            following lines where we treat detected.lang differently depending on if it is multi_lang or not.
+            """
             # If the message is english 70% english, just stop
             return
 
@@ -138,22 +69,27 @@ class GoogleTranslate(commands.Cog):
             lang = detected.lang[0].lower()
             lang_2 = detected.lang[1].lower()
             confidence = detected.confidence[0]  # extract value from confidence list
-            detected_language = f'{self.gl[lang]}, {self.gl[lang_2]}'
+            detected_language = f"{LANGUAGES[lang]}, {LANGUAGES[lang_2]}".title()
 
         else:
             lang = detected.lang.lower()
             confidence = detected.confidence
-            detected_language = f'{self.gl[lang]}'
+            detected_language = LANGUAGES[lang].title()
 
         # translate message
         translation = self.translator.translate(message.content, dest='en')
 
         # send results of translation as embed
         embed = discord.Embed(
-            title=f'{message.content}:',
-            description=f'{translation.text}')
+            title=f"{message.content}:",
+            description=f"{translation.text}")
 
-        embed.set_footer(text=f"translated from {detected_language}\nconfidence: {confidence * 100}%")
+            footer = f"translated from {detected_language}\nconfidence: {confidence * 100:0.2f}%"
+            pronunciation = translation.extra_data["translation"][1:]
+            if pronunciation:
+                footer += f"\npronunciation: ({pronunciation[0][-1].lower()})"
+
+        embed.set_footer(text=footer)
         await message.channel.send(embed=embed)
 
     @commands.slash_command()
@@ -165,22 +101,33 @@ class GoogleTranslate(commands.Cog):
         try:
             translated = self.translator.translate(text, dest=source_language)
             embed = discord.Embed(
-                title=f'{text}:',
+                title=f"{text}:",
                 description=translated.text
             )
-            embed.set_footer(text=f'translated from {self.gl[source_language]}')
+            footer = f"translated from {LANGUAGES[source_language]}"
+            pronunciation = translation.extra_data["translation"][1:]
+            if pronunciation:
+                footer += f"\npronunciation: ({pronunciation[0][-1].lower()})"
+
+            embed.set_footer(text=footer)
             await ctx.respond(embed=embed)
 
         except ValueError as v:
-            languages = ''
-            for key, value in self.gl.items():
-                languages += f'{key}: {value}\n'
+            count = 0
+            languages = ""
+            n = 3
+            # Print languages & codes n (3) to a row
+            for key, value in LANGUAGES.items():
+                if count % n == 0: 
+                    languages += "\n"
+                languages += f"{value.title()}-{key}".ljust(30)
+                count += 1
+
             embed = discord.Embed(
-                title='Valid Language Codes:',
+                title="Valid Language Codes:",
                 description=languages
             )
-            embed.set_footer(text='''Please use the code on the left
-    to select the language on the right''')
+            embed.set_footer(text="Please use the 2 digit code for your desired language.\n(Chinese codes are 5 digits)")
             await ctx.respond(embed=embed)
 
 

--- a/src/zorak/utilities/cog_helpers/whitelist.txt
+++ b/src/zorak/utilities/cog_helpers/whitelist.txt
@@ -1,0 +1,78 @@
+Python
+Variable
+Function
+Module
+List
+Tuple
+Dictionary
+Loop
+Conditional
+Class
+Inheritance
+Polymorphism
+Exception
+Object
+Method
+Argument
+Parameter
+Package
+Library
+Syntax
+Statement
+Import
+Return
+True
+False
+None
+Print
+Input
+File
+Error
+Debug
+IDE (Integrated Development Environment)
+Git
+GitHub
+Data
+Algorithm
+Algorithmic
+List Comprehension
+Dictionary Comprehension
+Recursion
+Lambda
+Generator
+Virtual Environment
+PIP (Python Package Index)
+Interpreter
+Bytecode
+GIL (Global Interpreter Lock)
+IDE (Interactive Development Environment)
+JSON (JavaScript Object Notation)
+API (Application Programming Interface)
+NumPy
+Pandas
+Matplotlib
+Seaborn
+Scikit-learn
+TensorFlow
+Keras
+PyTorch
+Django
+Flask
+Requests
+Beautiful Soup
+SQLAlchemy
+NLTK
+OpenCV
+Pillow
+Gensim
+SciPy
+SymPy
+pytest
+unittest
+pytest-django
+pytest-cov
+pytest-mock
+pypi
+haha
+pip
+docker


### PR DESCRIPTION
Clean up includes fixing a bit of the imports to look cleaner, adding the whitelist as a .txt file to the bot to read instead of hardcoding it and taking up so many lines of code. This can be moved to the DB if you prefer..., LANGUAGES is a dictionary we import from the google_trans module so there is no real need to add it to the class' namespace, changed the capitalization of the output of Language Names, and adjusted the confidence percentage to have only two decimal places, and output the list of language codes in 3 columns of text instead of 1 long one. (This might look bad on mobile... I am not sure).

I have commented three places where I am unsure if the code is necessary/good practice: 1) the self.threshold variable is never used... 2) The bot does not respond to messages shorter than 7 characters... we do not let it translate short words?  and 3) I am not confident the detection of "en" is done the best way.

Finally I have added pronunciation to the footer for languages that provide it.