### PR TITLE
fix: Added Python 3.11 to Linter

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,4 +20,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files '.\src\*.py')
+        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files 'src\*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,4 +20,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files '*.py')
+        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files 'src\*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,4 +20,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files 'src\*.py')
+        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files '*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9, 3.10"]
+        python-version: ["3.9", "3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9, 3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,4 +20,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --fail-under=7 -d E0401,R0903 $(git ls-files '*.py')
+        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files '.\src\*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,4 +20,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files 'src\*.py')
+        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files '.\src\*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,4 +20,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files '.\src\*.py')
+        pylint --fail-under=7 -d E0401,R0903,R0801 $(git ls-files '*.py')


### PR DESCRIPTION
Start linting for Python 3.10, because I want to move docker up