### PR TITLE
minor: Bump docker image from Python 3.9.16 -> 3.11.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.16-slim-buster AS builder-image
+FROM python:3.11.5-slim-bullseye AS builder-image
 ENV PYTHONUNBUFFERED=1
 
 COPY . /code


### PR DESCRIPTION
Tested in my local, working fine. 