### PR TITLE
Emergency Fix of /run command

### DIFF
--- a/src/zorak/cogs/utility/utility_message_tracker_cleanup.py
+++ b/src/zorak/cogs/utility/utility_message_tracker_cleanup.py
@@ -1,0 +1,35 @@
+"""
+Detects message links, and sends a preview of the message that is linked.
+"""
+import math
+import discord
+from discord.ext import commands, tasks
+from datetime import timedelta
+
+class MessageTrackerCleanup(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.message_tracker = {"test": {"created_at": discord.utils.utcnow(), "embed_id": "test"}}
+        self.cleanup_message_tracker.start()
+
+    @tasks.loop(hours=24)
+    async def cleanup_message_tracker(self):
+        current_time = discord.utils.utcnow()
+        keys_to_remove = []
+        
+        for user_message_id, contents in self.message_tracker.items():
+            message_date = contents["created_at"]
+            if current_time - message_date >= timedelta(hours=24):
+                keys_to_remove.append(user_message_id)
+        
+        for key in keys_to_remove:
+            self.message_tracker.pop(key)
+
+    @cleanup_message_tracker.before_loop
+    async def before_cleanup_message_tracker(self):
+        await self.bot.wait_until_ready()
+
+
+def setup(bot):
+    cleaner = MessageTrackerCleanup(bot)
+    bot.add_cog(cleaner)


### PR DESCRIPTION
!! Noticed the changes made to the /run command had Zorak deleting his embed for ANY previous code run, not just the ones that had been edited.  This means if I ran a /run command after someone else, the embedded result of their code would be deleted in place of my new unrelated code being run.

To accomplish this I changed the structure of what was happening. Rather than keeping just the id of the previous message as a class attribute, I have made a new cog which stores a message log as a dict which stores the user's message id, the date it was created, and the id of the bot's embed that follows the command as a nested dictionary. This combined with a conditional call to ctx.message.edited_at, Zorak is now able to tell exactly what message he is replying to and whether or not it is an original message or an edited one.

Now because he can edit any /run command result within the last 24 hours, I have changed the embed to a reply instead of a send so even if there had been other messages in the channel, the embed would link (via the reply link) to the code which it refers to.

Also. Because this dictionary inside the cog could potentially get very large, I have attempted a cleanup function using pycord's tasks. Ideally this function will be run every 24 hours, removing old dictionary items. I have tested it with the settings on 1 minute and it seems to work but have not obviously tested it with 24 hours.

If this cog setup/ structure is not ideal I am not adverse to changing it (for example if it belongs in cog_helpers instead of cogs/utilities....  or if you are against running the looped task every 24 hours....)  Please feel free to make changes as appropriate.