### PR TITLE
Fix/run code response length

### DIFF
--- a/Resources/ServerConfig/PracticalPython/channel_info.toml
+++ b/Resources/ServerConfig/PracticalPython/channel_info.toml
@@ -28,6 +28,7 @@ python_help_2 = 903542494409674803
 challenges_channel = 1045104938071633994
 news_channel = 1071848336442794094
 suggestions_channel = 962415552737996800
+bot_spam_channel = 903542513493749760
 
 [channels.log_channel]
 server_change_log = 953545221260595280

--- a/Resources/ServerConfig/Zorak-Dev/channel_info.toml
+++ b/Resources/ServerConfig/Zorak-Dev/channel_info.toml
@@ -28,6 +28,7 @@ python_help_2 = 12345
 challenges_channel = 1045104938071633994
 news_channel = 1071095960538718261
 suggestions_channel = 1179390629999026207
+bot_spam_channel = 1229687584905760809
 
 
 [channels.log_channel]

--- a/src/zorak/cogs/utility/utility_run_code.py
+++ b/src/zorak/cogs/utility/utility_run_code.py
@@ -28,20 +28,28 @@ class UtilityRunCode(commands.Cog):
         else:
             embed = discord.Embed(colour=discord.Colour.green(), title="Python 3.10")
 
-        for i, field in enumerate(chop_dat_boi_up(value, 1000)):  # Discord only supports fields with 1024 chars
+        size = 11  # start counting how big the embed is.
+
+        for i, field in enumerate(chop_dat_boi_up(value, 500)):  # Discord only supports fields with 1024 chars
+
             if i != 0:
-                if i <= 25:  # Discord only supports 25 add_fields
+                size += len(field)
+                if size < 6000:  # Discord only supports EMBEDS with a total character size of 6000
+                    print(field)
                     embed.add_field(
                         name="\u200b",
                         value=field,
+                        inline=False
                         # pylint: disable=W1401
                     )
             else:
-                embed.add_field(
-                    name=name,
-                    value=field,
-                    # pylint: disable=W1401
-                )
+                size += len(field)
+                if size < 6000:
+                    embed.add_field(
+                        name=name,
+                        value=field,
+                        # pylint: disable=W1401
+                    )
         return embed
 
     @commands.command()

--- a/src/zorak/cogs/utility/utility_run_code.py
+++ b/src/zorak/cogs/utility/utility_run_code.py
@@ -22,19 +22,24 @@ class UtilityRunCode(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    def get_embed(self, name, value, is_error=False):
+    def get_embed(self, name, value, channel, is_error=False):
         if is_error:
             embed = discord.Embed(colour=discord.Colour.red(), title="Oops...")
         else:
             embed = discord.Embed(colour=discord.Colour.green(), title="Python 3.10")
 
         size = 11  # start counting how big the embed is.
+        max_size = 1000 # Default to 1000 chars.
+
+        # Check if the user is in the bot_spam channel, to allow for larger embeds.
+        print(self.bot.server_settings.normal_channel)
+        if channel.id == self.bot.server_settings.normal_channel['bot_spam_channel']:
+            max_size = 6000  # Discord limitation
 
         for i, field in enumerate(chop_dat_boi_up(value, 500)):  # Discord only supports fields with 1024 chars
-
             if i != 0:
                 size += len(field)
-                if size < 6000:  # Discord only supports EMBEDS with a total character size of 6000
+                if size < max_size:  # Discord only supports EMBEDS with a total character size of 6000
                     print(field)
                     embed.add_field(
                         name="\u200b",
@@ -44,7 +49,7 @@ class UtilityRunCode(commands.Cog):
                     )
             else:
                 size += len(field)
-                if size < 6000:
+                if size < max_size:
                     embed.add_field(
                         name=name,
                         value=field,
@@ -95,19 +100,19 @@ class UtilityRunCode(commands.Cog):
 
             piston = PistonAPI()
             runcode = piston.execute(language="py", version="3.10.0", code=codeblock)
-            embed = self.get_embed("Output:", runcode)
+            embed = self.get_embed("Output:", runcode, ctx.channel)
             message = await ctx.reply(embed=embed)
 
         elif codeblock.startswith("'''") and codeblock.endswith("'''"):
             value = "Did you mean to use a \` instead of a ' ?\n\`\`\`py Your code here \`\`\`"
-            embed = self.get_embed("Formatting error", value, True)
+            embed = self.get_embed("Formatting error", value, ctx.channel, True)
             message = await ctx.channel.send(embed=embed)
 
         else:
             print(codeblock)
             value = 'Please place your code inside a code block. (between \`\`\`py ' \
                     'and \`\`\`)\n\n\`\`\`py \nx = "like this"\nprint(x) \n\`\`\`'
-            embed = self.get_embed("Formatting error", value, True)
+            embed = self.get_embed("Formatting error", value, ctx.channel, True)
             message = await ctx.channel.send(embed=embed)
 
     @commands.Cog.listener()

--- a/src/zorak/cogs/utility/utility_run_code.py
+++ b/src/zorak/cogs/utility/utility_run_code.py
@@ -11,6 +11,11 @@ from discord.ext import commands
 logger = logging.getLogger(__name__)
 
 
+def chop_dat_boi_up(string, chunk_size):
+    # vOmIt #
+    return [string[i:i + chunk_size] for i in range(0, len(string), chunk_size)]
+
+
 class UtilityRunCode(commands.Cog):
     """Uses PistonAPI to run code in the server."""
 
@@ -22,11 +27,21 @@ class UtilityRunCode(commands.Cog):
             embed = discord.Embed(colour=discord.Colour.red(), title="Oops...")
         else:
             embed = discord.Embed(colour=discord.Colour.green(), title="Python 3.10")
-        embed.add_field(
-            name=name,
-            value=value,
-            # pylint: disable=W1401
-        )
+
+        for i, field in enumerate(chop_dat_boi_up(value, 1000)):  # Discord only supports fields with 1024 chars
+            if i != 0:
+                if i <= 25:  # Discord only supports 25 add_fields
+                    embed.add_field(
+                        name="\u200b",
+                        value=field,
+                        # pylint: disable=W1401
+                    )
+            else:
+                embed.add_field(
+                    name=name,
+                    value=field,
+                    # pylint: disable=W1401
+                )
         return embed
 
     @commands.command()


### PR DESCRIPTION
**_Please review my code, because this can be improved for sure._** 

Adds embed handling for code responses longer than 1000 chars. Also caps the limit for the size of an embed to 6000 total characters. 

> If you plan on using embed responses for your bot you should know the limits of the embeds on Discord or you will get Invalid Form Body errors:
> 
>     Embed title is limited to 256 characters
>     Embed description is limited to 4096 characters
>     An embed can contain a maximum of 25 fields
>     A field name/title is limited to 256 character and the value of the field is limited to 1024 characters
>     Embed footer is limited to 2048 characters
>     Embed author name is limited to 256 characters
>     The total of characters allowed in an embed is 6000