### PR TITLE
docs(general_help): typo in command output

### DIFF
--- a/src/zorak/cogs/general/general_help.py
+++ b/src/zorak/cogs/general/general_help.py
@@ -35,7 +35,7 @@ class HelpButtons(discord.ui.View):
             f"**Owner** \n{interaction.guild.owner.mention}\n\n"  # pylint: disable=W1401
             f"**Email** \n{self.server_settings.server_info['email']}\n\n"  # pylint: disable=W1401
             f"**Invite Link** \n{self.server_settings.server_info['invite']}\n\n"  # pylint: disable=W1401
-            f"**Leave a reveiw** \n{self.server_settings.server_info['review']}\n\n"  # pylint: disable=W1401
+            f"**Leave a review** \n{self.server_settings.server_info['review']}\n\n"  # pylint: disable=W1401
             f"**Questions?** \nMake a ticket using **/ticket**, or send us an email.",
             color=discord.Color.yellow(),
         )


### PR DESCRIPTION
Simple typo fix. (reveiw -> review) 